### PR TITLE
Changed circular_buffer_read and circular_buffer_peek functions to trans...

### DIFF
--- a/src/libchitcp/buffer.c
+++ b/src/libchitcp/buffer.c
@@ -85,7 +85,7 @@ int circular_buffer_read(circular_buffer_t *buf, uint8_t *dst, uint32_t len, boo
         toread = (buf->end - buf->start);
 
     if(dst)
-        memcpy(dst, buf->data + buf->start, len);
+        memcpy(dst, buf->data + buf->start, toread);
     buf->start += toread;
     buf->seq_start += toread;
 
@@ -102,7 +102,7 @@ int circular_buffer_peek(circular_buffer_t *buf, uint8_t *dst, uint32_t len, boo
         toread = (buf->end - buf->start);
 
     if(dst)
-        memcpy(dst, buf->data + buf->start, len);
+        memcpy(dst, buf->data + buf->start, toread);
 
     return toread;
 }


### PR DESCRIPTION
...fer  bytes from the circular buffer to the destination buffer rather than the maximum allowable length . This prevents a buffer overflow error.

Notice that these functons compute a `toread` variable (which is supposed to represent the number of bytes read from the circular buffer), but this value isn't actually used.  Instead, `len` is passed as the length argument to `memcpy` -- this seems to be a typo.
